### PR TITLE
Support multi plugins for one target class

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/plugin/AbstractClassEnhancePluginDefine.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/plugin/AbstractClassEnhancePluginDefine.java
@@ -24,7 +24,7 @@ public abstract class AbstractClassEnhancePluginDefine {
      *
      * @param transformClassName target class.
      * @param builder            byte-buddy's builder to manipulate target class's bytecode.
-     * @return be defined builder.
+     * @return the new builder, or <code>null</code> if not be enhanced.
      * @throws PluginException, when set builder failure.
      */
     public DynamicType.Builder<?> define(String transformClassName,
@@ -33,7 +33,7 @@ public abstract class AbstractClassEnhancePluginDefine {
 
         if (StringUtil.isEmpty(transformClassName)) {
             logger.warn("classname of being intercepted is not defined by {}.", interceptorDefineClassName);
-            return builder;
+            return null;
         }
 
         logger.debug("prepare to enhance class {} by {}.", transformClassName, interceptorDefineClassName);
@@ -48,7 +48,7 @@ public abstract class AbstractClassEnhancePluginDefine {
                 if (!witnessClassResolution.isResolved()) {
                     logger.warn("enhance class {} by plugin {} is not working. Because witness class {} is not existed.", transformClassName, interceptorDefineClassName,
                         witnessClass);
-                    return builder;
+                    return null;
                 }
             }
         }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/plugin/PluginFinder.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/plugin/PluginFinder.java
@@ -1,6 +1,7 @@
 package org.skywalking.apm.agent.core.plugin;
 
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -11,7 +12,7 @@ import java.util.Map;
  * @author wusheng
  */
 public class PluginFinder {
-    private final Map<String, AbstractClassEnhancePluginDefine> pluginDefineMap = new HashMap<String, AbstractClassEnhancePluginDefine>();
+    private final Map<String, LinkedList<AbstractClassEnhancePluginDefine>> pluginDefineMap = new HashMap<String, LinkedList<AbstractClassEnhancePluginDefine>>();
 
     public PluginFinder(List<AbstractClassEnhancePluginDefine> plugins) {
         for (AbstractClassEnhancePluginDefine plugin : plugins) {
@@ -21,11 +22,17 @@ public class PluginFinder {
                 continue;
             }
 
-            pluginDefineMap.put(enhanceClassName, plugin);
+            LinkedList<AbstractClassEnhancePluginDefine> pluginDefinesWithSameTarget = pluginDefineMap.get(enhanceClassName);
+            if (pluginDefinesWithSameTarget == null) {
+                pluginDefinesWithSameTarget = new LinkedList<AbstractClassEnhancePluginDefine>();
+                pluginDefineMap.put(enhanceClassName, pluginDefinesWithSameTarget);
+            }
+
+            pluginDefinesWithSameTarget.add(plugin);
         }
     }
 
-    public AbstractClassEnhancePluginDefine find(String enhanceClassName) {
+    public List<AbstractClassEnhancePluginDefine> find(String enhanceClassName) {
         if (pluginDefineMap.containsKey(enhanceClassName)) {
             return pluginDefineMap.get(enhanceClassName);
         }


### PR DESCRIPTION
This pr is for fixing #192.

Adjust `PluginFinder.pluginDefineMap`. With the <string, list> data construction, multi plugins can target same class, of source only one will enhance the target class actually.

@bai-yang I think you are interested in this.

cc @sky-walking