### PR TITLE
The operation name of Resin plugin isn't accurately when dispatch request in JSP page

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/resin-3.x-plugin/src/main/java/org/skywalking/apm/plugin/resin/v3/ResinV3Interceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/resin-3.x-plugin/src/main/java/org/skywalking/apm/plugin/resin/v3/ResinV3Interceptor.java
@@ -1,5 +1,6 @@
 package org.skywalking.apm.plugin.resin.v3;
 
+import com.caucho.server.connection.CauchoRequest;
 import com.caucho.server.http.HttpResponse;
 import com.caucho.server.http.HttpRequest;
 import org.skywalking.apm.agent.core.context.ContextCarrier;
@@ -33,13 +34,13 @@ public class ResinV3Interceptor implements InstanceMethodsAroundInterceptor {
     public void beforeMethod(EnhancedClassInstanceContext context, InstanceMethodInvokeContext interceptorContext,
         MethodInterceptResult result) {
         Object[] args = interceptorContext.allArguments();
-        HttpRequest request = (HttpRequest)args[0];
-        Span span = ContextManager.createSpan(request.getRequestURI());
+        CauchoRequest request = (CauchoRequest)args[0];
+        Span span = ContextManager.createSpan(request.getPageURI());
         Tags.COMPONENT.set(span, RESIN_COMPONENT);
         Tags.PEER_HOST.set(span, request.getServerName());
         Tags.PEER_PORT.set(span, request.getServerPort());
         Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_SERVER);
-        Tags.URL.set(span, request.getRequestURL().toString());
+        Tags.URL.set(span, request.getPageURI().toString());
         Tags.SPAN_LAYER.asHttp(span);
 
         String tracingHeaderValue = request.getHeader(HEADER_NAME_OF_CONTEXT_DATA);

--- a/apm-sniffer/apm-sdk-plugin/resin-4.x-plugin/src/main/java/org/skywalking/apm/plugin/resin/v4/ResinV4Interceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/resin-4.x-plugin/src/main/java/org/skywalking/apm/plugin/resin/v4/ResinV4Interceptor.java
@@ -1,8 +1,8 @@
 package org.skywalking.apm.plugin.resin.v4;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import com.caucho.server.http.CauchoRequest;
 import com.caucho.server.http.HttpRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.skywalking.apm.agent.core.context.ContextCarrier;
 import org.skywalking.apm.agent.core.context.ContextManager;
 import org.skywalking.apm.agent.core.plugin.interceptor.EnhancedClassInstanceContext;
@@ -31,13 +31,13 @@ public class ResinV4Interceptor implements InstanceMethodsAroundInterceptor {
     public void beforeMethod(EnhancedClassInstanceContext context, InstanceMethodInvokeContext interceptorContext,
         MethodInterceptResult result) {
         Object[] args = interceptorContext.allArguments();
-        HttpServletRequest request = (HttpServletRequest)args[0];
-        Span span = ContextManager.createSpan(request.getRequestURI());
+        CauchoRequest request = (CauchoRequest)args[0];
+        Span span = ContextManager.createSpan(request.getPageURI());
         Tags.COMPONENT.set(span, RESIN_COMPONENT);
         Tags.PEER_HOST.set(span, request.getServerName());
         Tags.PEER_PORT.set(span, request.getServerPort());
         Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_SERVER);
-        Tags.URL.set(span, request.getRequestURL().toString());
+        Tags.URL.set(span, request.getPageURI().toString());
         Tags.SPAN_LAYER.asHttp(span);
 
         String tracingHeaderValue = request.getHeader(HEADER_NAME_OF_CONTEXT_DATA);


### PR DESCRIPTION
Here are the result graph.

Topological graph:
<img width="1437" alt="wx20170511-141401 2x" src="https://cloud.githubusercontent.com/assets/12436447/25935146/254bb174-3654-11e7-8c8a-07d9b4e00843.png">

Trace graph of Resin 3 
![resin3](https://cloud.githubusercontent.com/assets/12436447/25935226/a639410c-3654-11e7-975c-971a22478e8b.png)

Trace graph of Resin 4
![resin4](https://cloud.githubusercontent.com/assets/12436447/25935235/ad2c00da-3654-11e7-842f-761408dd4b61.png)
