### PR TITLE
The operation name of Resin plugin isn't accurately when dispatch request in JSP page

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/resin-3.x-plugin/src/main/java/org/skywalking/apm/plugin/resin/v3/ResinV3Interceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/resin-3.x-plugin/src/main/java/org/skywalking/apm/plugin/resin/v3/ResinV3Interceptor.java
@@ -1,7 +1,8 @@
 package org.skywalking.apm.plugin.resin.v3;
 
-import com.caucho.server.http.HttpResponse;
+import com.caucho.server.connection.CauchoRequest;
 import com.caucho.server.http.HttpRequest;
+import com.caucho.server.http.HttpResponse;
 import org.skywalking.apm.agent.core.context.ContextCarrier;
 import org.skywalking.apm.agent.core.context.ContextManager;
 import org.skywalking.apm.agent.core.plugin.interceptor.EnhancedClassInstanceContext;
@@ -33,19 +34,36 @@ public class ResinV3Interceptor implements InstanceMethodsAroundInterceptor {
     public void beforeMethod(EnhancedClassInstanceContext context, InstanceMethodInvokeContext interceptorContext,
         MethodInterceptResult result) {
         Object[] args = interceptorContext.allArguments();
-        HttpRequest request = (HttpRequest)args[0];
-        Span span = ContextManager.createSpan(request.getRequestURI());
+        CauchoRequest request = (CauchoRequest)args[0];
+        Span span = ContextManager.createSpan(request.getPageURI());
         Tags.COMPONENT.set(span, RESIN_COMPONENT);
         Tags.PEER_HOST.set(span, request.getServerName());
         Tags.PEER_PORT.set(span, request.getServerPort());
         Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_SERVER);
-        Tags.URL.set(span, request.getRequestURL().toString());
+        Tags.URL.set(span, appendRequestURL(request));
         Tags.SPAN_LAYER.asHttp(span);
 
         String tracingHeaderValue = request.getHeader(HEADER_NAME_OF_CONTEXT_DATA);
         if (!StringUtil.isEmpty(tracingHeaderValue)) {
             ContextManager.extract(new ContextCarrier().deserialize(tracingHeaderValue));
         }
+    }
+
+    /**
+     * Append request URL.
+     *
+     * @param request
+     * @return
+     */
+    private String appendRequestURL(CauchoRequest request) {
+        StringBuffer sb = new StringBuffer();
+        sb.append(request.getScheme());
+        sb.append("://");
+        sb.append(request.getServerName());
+        sb.append(":");
+        sb.append(request.getServerPort());
+        sb.append(request.getPageURI());
+        return sb.toString();
     }
 
     @Override

--- a/apm-sniffer/apm-sdk-plugin/resin-3.x-plugin/src/test/java/org/skywalking/apm/plugin/resin/v3/ResinV3InterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/resin-3.x-plugin/src/test/java/org/skywalking/apm/plugin/resin/v3/ResinV3InterceptorTest.java
@@ -1,7 +1,7 @@
 package org.skywalking.apm.plugin.resin.v3;
 
+import com.caucho.server.connection.CauchoRequest;
 import com.caucho.server.http.HttpResponse;
-import com.caucho.server.http.HttpRequest;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
@@ -39,7 +39,7 @@ public class ResinV3InterceptorTest {
     private MockTracerContextListener contextListener;
 
     @Mock
-    private HttpRequest request;
+    private CauchoRequest request;
     @Mock
     private HttpResponse response;
     @Mock
@@ -59,7 +59,10 @@ public class ResinV3InterceptorTest {
 
         TracerContext.ListenerManager.add(contextListener);
 
-        when(request.getRequestURI()).thenReturn("/test/testRequestURL");
+        when(request.getPageURI()).thenReturn("/test/testRequestURL");
+        when(request.getScheme()).thenReturn("http");
+        when(request.getServerName()).thenReturn("localhost");
+        when(request.getServerPort()).thenReturn(8080);
         when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/test/testRequestURL"));
         when(response.getStatusCode()).thenReturn(200);
         when(methodInvokeContext.allArguments()).thenReturn(new Object[] {request, response});

--- a/apm-sniffer/apm-sdk-plugin/resin-4.x-plugin/src/main/java/org/skywalking/apm/plugin/resin/v4/ResinV4Interceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/resin-4.x-plugin/src/main/java/org/skywalking/apm/plugin/resin/v4/ResinV4Interceptor.java
@@ -1,8 +1,8 @@
 package org.skywalking.apm.plugin.resin.v4;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import com.caucho.server.http.CauchoRequest;
 import com.caucho.server.http.HttpRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.skywalking.apm.agent.core.context.ContextCarrier;
 import org.skywalking.apm.agent.core.context.ContextManager;
 import org.skywalking.apm.agent.core.plugin.interceptor.EnhancedClassInstanceContext;
@@ -31,19 +31,36 @@ public class ResinV4Interceptor implements InstanceMethodsAroundInterceptor {
     public void beforeMethod(EnhancedClassInstanceContext context, InstanceMethodInvokeContext interceptorContext,
         MethodInterceptResult result) {
         Object[] args = interceptorContext.allArguments();
-        HttpServletRequest request = (HttpServletRequest)args[0];
-        Span span = ContextManager.createSpan(request.getRequestURI());
+        CauchoRequest request = (CauchoRequest)args[0];
+        Span span = ContextManager.createSpan(request.getPageURI());
         Tags.COMPONENT.set(span, RESIN_COMPONENT);
         Tags.PEER_HOST.set(span, request.getServerName());
         Tags.PEER_PORT.set(span, request.getServerPort());
         Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_SERVER);
-        Tags.URL.set(span, request.getRequestURL().toString());
+        Tags.URL.set(span, appendRequestURL(request));
         Tags.SPAN_LAYER.asHttp(span);
 
         String tracingHeaderValue = request.getHeader(HEADER_NAME_OF_CONTEXT_DATA);
         if (!StringUtil.isEmpty(tracingHeaderValue)) {
             ContextManager.extract(new ContextCarrier().deserialize(tracingHeaderValue));
         }
+    }
+
+    /**
+     * Append request URL.
+     *
+     * @param request
+     * @return
+     */
+    private String appendRequestURL(CauchoRequest request) {
+        StringBuffer sb = new StringBuffer();
+        sb.append(request.getScheme());
+        sb.append("://");
+        sb.append(request.getServerName());
+        sb.append(":");
+        sb.append(request.getServerPort());
+        sb.append(request.getPageURI());
+        return sb.toString();
     }
 
     @Override

--- a/apm-sniffer/apm-sdk-plugin/resin-4.x-plugin/src/test/java/org/skywalking/apm/plugin/resin/v4/ResinV4InterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/resin-4.x-plugin/src/test/java/org/skywalking/apm/plugin/resin/v4/ResinV4InterceptorTest.java
@@ -1,6 +1,7 @@
 package org.skywalking.apm.plugin.resin.v4;
 
-import javax.servlet.http.HttpServletRequest;
+import com.caucho.server.http.CauchoRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
@@ -20,7 +21,6 @@ import org.skywalking.apm.trace.Span;
 import org.skywalking.apm.trace.TraceSegment;
 import org.skywalking.apm.trace.TraceSegmentRef;
 import org.skywalking.apm.trace.tag.Tags;
-import javax.servlet.http.HttpServletResponse;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -37,7 +37,7 @@ public class ResinV4InterceptorTest {
     private MockTracerContextListener contextListener;
 
     @Mock
-    private HttpServletRequest request;
+    private CauchoRequest request;
     @Mock
     private HttpServletResponse response;
     @Mock
@@ -57,6 +57,10 @@ public class ResinV4InterceptorTest {
 
         TracerContext.ListenerManager.add(contextListener);
 
+        when(request.getPageURI()).thenReturn("/test/testRequestURL");
+        when(request.getScheme()).thenReturn("http");
+        when(request.getServerName()).thenReturn("localhost");
+        when(request.getServerPort()).thenReturn(8080);
         when(request.getRequestURI()).thenReturn("/test/testRequestURL");
         when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/test/testRequestURL"));
         when(response.getStatus()).thenReturn(200);


### PR DESCRIPTION
Here are the result graph.

Topological graph:
<img width="1437" alt="wx20170511-141401 2x" src="https://cloud.githubusercontent.com/assets/12436447/25935146/254bb174-3654-11e7-8c8a-07d9b4e00843.png">

Trace graph of Resin 3:
![resin3](https://cloud.githubusercontent.com/assets/12436447/25935226/a639410c-3654-11e7-975c-971a22478e8b.png)

Trace graph of Resin 4:
![resin4](https://cloud.githubusercontent.com/assets/12436447/25935235/ad2c00da-3654-11e7-842f-761408dd4b61.png)


span graph:
<img width="979" alt="wx20170512-151636 2x" src="https://cloud.githubusercontent.com/assets/12436447/25987594/46cc7e86-3727-11e7-9d18-e6c3cdef663a.png">
