### PR TITLE
Fix NullPointerException when deserialize tags of span

### DIFF
--- a/apm-collector/apm-collector-worker/src/main/java/org/skywalking/apm/collector/worker/segment/entity/Span.java
+++ b/apm-collector/apm-collector-worker/src/main/java/org/skywalking/apm/collector/worker/segment/entity/Span.java
@@ -1,6 +1,8 @@
 package org.skywalking.apm.collector.worker.segment.entity;
 
 import com.google.gson.annotations.SerializedName;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -25,16 +27,16 @@ public class Span {
     private String operationName;
 
     @SerializedName("ts")
-    private Map<String, String> tagsWithStr;
+    private Map<String, String> tagsWithStr = new LinkedHashMap<>();
 
     @SerializedName("tb")
-    private Map<String, Boolean> tagsWithBool;
+    private Map<String, Boolean> tagsWithBool = new LinkedHashMap<>();
 
     @SerializedName("ti")
-    private Map<String, Integer> tagsWithInt;
+    private Map<String, Integer> tagsWithInt = new LinkedHashMap<>();
 
     @SerializedName("lo")
-    private List<LogData> logs;
+    private List<LogData> logs = new LinkedList<>();
 
     public int getSpanId() {
         return spanId;


### PR DESCRIPTION
If `Span` does not have `tagsWithBool` , the serialization data does not contain `tagsWithBool` data, and the collector does not initialize the` tagsWithBool` field during deserialize, and it will cause NullPointerException when operation `tagsWithBool` field.