### PR TITLE
Fix windows script start collector failure.

### DIFF
--- a/apm-collector/apm-collector-worker/bin/collector-service.bat
+++ b/apm-collector/apm-collector-worker/bin/collector-service.bat
@@ -8,10 +8,13 @@ set COLLECTOR_RUNTIME_OPTIONS="-Xms256M -Xmx512M"
 set CLASSPATH=%COLLECTOR_BASE_PATH%\config;
 SET CLASSPATH=%COLLECTOR_BASE_PATH%\libs\*;%CLASSPATH%
 
-if ""%JAVA_HOME%"" == """" (
-  set _EXECJAVA=java
-) else (
-  set _EXECJAVA="%JAVA_HOME%"/bin/java
+if defined JAVA_HOME (
+ set _EXECJAVA="%JAVA_HOME:"=%"\bin\java
+)
+
+if not defined JAVA_HOME (
+ echo "JAVA_HOME not set."
+ set _EXECJAVA=java
 )
 
 start /MIN "%COLLECOTR_PROCESS_TITLE%" %_EXECJAVA% "%COLLECTOR_RUNTIME_OPTIONS%" -cp "%CLASSPATH%" org.skywalking.apm.collector.worker.CollectorBootStartUp &


### PR DESCRIPTION
Ref: #250 

**Cause**:
The startup script did not handle the JAVA_HOME path with space.

