### PR TITLE
Optimize the entry span’s operationName

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/context/TracingContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/context/TracingContext.java
@@ -202,7 +202,7 @@ public class TracingContext implements AbstractTracerContext {
         final int parentSpanId = parentSpan == null ? -1 : parentSpan.getSpanId();
         if (parentSpan == null) {
             entrySpan = (AbstractTracingSpan)DictionaryManager.findOperationNameCodeSection()
-                .find(segment.getApplicationId(), operationName)
+                .findOnly(segment.getApplicationId(), operationName)
                 .doInCondition(new PossibleFound.FoundAndObtain() {
                     @Override public Object doProcess(int operationId) {
                         return new EntrySpan(spanIdGenerator++, parentSpanId, operationId);
@@ -216,7 +216,7 @@ public class TracingContext implements AbstractTracerContext {
             return push(entrySpan);
         } else if (parentSpan.isEntry()) {
             entrySpan = (AbstractTracingSpan)DictionaryManager.findOperationNameCodeSection()
-                .find(segment.getApplicationId(), operationName)
+                .findOnly(segment.getApplicationId(), operationName)
                 .doInCondition(new PossibleFound.FoundAndObtain() {
                     @Override public Object doProcess(int operationId) {
                         return parentSpan.setOperationId(operationId);
@@ -244,7 +244,7 @@ public class TracingContext implements AbstractTracerContext {
         AbstractTracingSpan parentSpan = peek();
         final int parentSpanId = parentSpan == null ? -1 : parentSpan.getSpanId();
         AbstractTracingSpan span = (AbstractTracingSpan)DictionaryManager.findOperationNameCodeSection()
-            .find(segment.getApplicationId(), operationName)
+            .findOrPrepare4Register(segment.getApplicationId(), operationName)
             .doInCondition(new PossibleFound.FoundAndObtain() {
                 @Override
                 public Object doProcess(int operationId) {
@@ -282,7 +282,7 @@ public class TracingContext implements AbstractTracerContext {
                         @Override
                         public Object doProcess(final int applicationId) {
                             return DictionaryManager.findOperationNameCodeSection()
-                                .find(applicationId, operationName)
+                                .findOrPrepare4Register(applicationId, operationName)
                                 .doInCondition(
                                     new PossibleFound.FoundAndObtain() {
                                         @Override

--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/dictionary/OperationNameDictionary.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/dictionary/OperationNameDictionary.java
@@ -20,7 +20,15 @@ public enum OperationNameDictionary {
     private Map<OperationNameKey, Integer> operationNameDictionary = new ConcurrentHashMap<OperationNameKey, Integer>();
     private Set<OperationNameKey> unRegisterOperationNames = new ConcurrentSet<OperationNameKey>();
 
-    public PossibleFound find(int applicationId, String operationName) {
+    public PossibleFound findOrPrepare4Register(int applicationId, String operationName) {
+        return find0(applicationId, operationName, true);
+    }
+
+    public PossibleFound findOnly(int applicationId, String operationName) {
+        return find0(applicationId, operationName, false);
+    }
+
+    private PossibleFound find0(int applicationId, String operationName, boolean registerWhenNotFound) {
         if (operationName == null || operationName.length() == 0) {
             return new NotFound();
         }
@@ -29,7 +37,8 @@ public enum OperationNameDictionary {
         if (operationId != null) {
             return new Found(applicationId);
         } else {
-            if (operationNameDictionary.size() + unRegisterOperationNames.size() < OPERATION_NAME_BUFFER_SIZE) {
+            if (registerWhenNotFound &&
+                operationNameDictionary.size() + unRegisterOperationNames.size() < OPERATION_NAME_BUFFER_SIZE) {
                 unRegisterOperationNames.add(key);
             }
             return new NotFound();

--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/plugin/AbstractClassEnhancePluginDefine.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/plugin/AbstractClassEnhancePluginDefine.java
@@ -37,7 +37,7 @@ public abstract class AbstractClassEnhancePluginDefine {
         logger.debug("prepare to enhance class {} by {}.", transformClassName, interceptorDefineClassName);
 
         /**
-         * find witness classes for enhance class
+         * findOrPrepare4Register witness classes for enhance class
          */
         String[] witnessClasses = witnessClasses();
         if (witnessClasses != null) {
@@ -51,7 +51,7 @@ public abstract class AbstractClassEnhancePluginDefine {
         }
 
         /**
-         * find origin class source code for interceptor
+         * findOrPrepare4Register origin class source code for interceptor
          */
         DynamicType.Builder<?> newClassBuilder = this.enhance(transformClassName, builder, classLoader);
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/plugin/PluginFinder.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/plugin/PluginFinder.java
@@ -16,7 +16,7 @@ import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
 /**
- * The <code>PluginFinder</code> represents a finder , which assist to find the one
+ * The <code>PluginFinder</code> represents a finder , which assist to findOrPrepare4Register the one
  * from the given {@link AbstractClassEnhancePluginDefine} list.
  *
  * @author wusheng

--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/plugin/PluginResourcesResolver.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/plugin/PluginResourcesResolver.java
@@ -27,7 +27,7 @@ public class PluginResourcesResolver {
             while (urls.hasMoreElements()) {
                 URL pluginUrl = urls.nextElement();
                 cfgUrlPaths.add(pluginUrl);
-                logger.info("find skywalking plugin define in {}", pluginUrl);
+                logger.info("findOrPrepare4Register skywalking plugin define in {}", pluginUrl);
             }
 
             return cfgUrlPaths;
@@ -42,7 +42,7 @@ public class PluginResourcesResolver {
      * First get current thread's classloader,
      * if fail, get {@link PluginResourcesResolver}'s classloader.
      *
-     * @return the classloader to find plugin definitions.
+     * @return the classloader to findOrPrepare4Register plugin definitions.
      */
     private ClassLoader getDefaultClassLoader() {
         ClassLoader cl = null;


### PR DESCRIPTION
I prepare this for the url, which includes the parameters, like some Spring controllers always did, except for me :( . e.g. `/order/save/{orderId}`.

When I want to capture a tomcat service with that style url, the operationName actually is `/order/save/OHXXXXX123`. But this url changes in every saving order operation. As changing happens, the dictionary/encoding mechanism didn't work, even cost more memory.

So I ask for supporting Spring plugin. #282 

But the agent core decided whether the  dictionary/encoding works or not, when creating `TracingContext#createEntrySpan`. So the actual url is still asked for encoding. 

I use this pr to fix this.