### PR TITLE
Change the data type of application instance id

### DIFF
--- a/apm-network/src/main/proto/JVMMetricsService.proto
+++ b/apm-network/src/main/proto/JVMMetricsService.proto
@@ -12,7 +12,7 @@ service JVMMetricsService {
 
 message JVMMetrics {
     repeated JVMMetric metrics = 1;
-    int64 applicationInstanceId = 2;
+    int32 applicationInstanceId = 2;
 }
 
 message JVMMetric {


### PR DESCRIPTION
from int 64 to int 32 in jvm metric service