### PR TITLE
Improve the register flow

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/conf/Config.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/conf/Config.java
@@ -41,7 +41,7 @@ public class Config {
         /**
          * application and service registry check interval
          */
-        public static long APP_AND_SERVICE_REGISTER_CHECK_INTERVAL = 10;
+        public static long APP_AND_SERVICE_REGISTER_CHECK_INTERVAL = 3;
         /**
          * discovery rest check interval
          */

--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/remote/AppAndServiceRegisterClient.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/remote/AppAndServiceRegisterClient.java
@@ -88,7 +88,7 @@ public class AppAndServiceRegisterClient implements BootService, GRPCChannelList
     @Override
     public void run() {
         boolean shouldTry = true;
-        while (CONNECTED.equals(status) & shouldTry) {
+        while (CONNECTED.equals(status) && shouldTry) {
             shouldTry = false;
             try {
                 if (RemoteDownstreamConfig.Agent.APPLICATION_ID == DictionaryUtil.nullValue()) {

--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/remote/AppAndServiceRegisterClient.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/remote/AppAndServiceRegisterClient.java
@@ -87,7 +87,9 @@ public class AppAndServiceRegisterClient implements BootService, GRPCChannelList
 
     @Override
     public void run() {
-        if (CONNECTED.equals(status)) {
+        boolean shouldTry = true;
+        while (CONNECTED.equals(status) & shouldTry) {
+            shouldTry = false;
             try {
                 if (RemoteDownstreamConfig.Agent.APPLICATION_ID == DictionaryUtil.nullValue()) {
                     if (applicationRegisterServiceBlockingStub != null) {
@@ -95,6 +97,7 @@ public class AppAndServiceRegisterClient implements BootService, GRPCChannelList
                             Application.newBuilder().addApplicationCode(Config.Agent.APPLICATION_CODE).build());
                         if (applicationMapping.getApplicationCount() > 0) {
                             RemoteDownstreamConfig.Agent.APPLICATION_ID = applicationMapping.getApplication(0).getValue();
+                            shouldTry = true;
                         }
                     }
                 } else {
@@ -119,6 +122,7 @@ public class AppAndServiceRegisterClient implements BootService, GRPCChannelList
                                     .setRegisterTime(System.currentTimeMillis())
                                     .setOsinfo(OSUtil.buildOSInfo())
                                     .build());
+                                needRegisterRecover = true;
                             } else {
                                 if (lastSegmentTime - System.currentTimeMillis() > 60 * 1000) {
                                     instanceDiscoveryServiceBlockingStub.heartbeat(ApplicationInstanceHeartbeat.newBuilder()

--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/remote/AppAndServiceRegisterClient.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/remote/AppAndServiceRegisterClient.java
@@ -122,7 +122,7 @@ public class AppAndServiceRegisterClient implements BootService, GRPCChannelList
                                     .setRegisterTime(System.currentTimeMillis())
                                     .setOsinfo(OSUtil.buildOSInfo())
                                     .build());
-                                needRegisterRecover = true;
+                                needRegisterRecover = false;
                             } else {
                                 if (lastSegmentTime - System.currentTimeMillis() > 60 * 1000) {
                                     instanceDiscoveryServiceBlockingStub.heartbeat(ApplicationInstanceHeartbeat.newBuilder()


### PR DESCRIPTION
1. Because of #483, I decide to trust collector. Switch needRegisterRecover to false, after call registerRecoverService successfully.
1. Add shouldTry for the AppAndServiceRegisterClient-Timer. If register application_id successfully, register application_instance_id immediately, don't wait because of timer's period.